### PR TITLE
feat: add-campo-data-sondagem

### DIFF
--- a/pages/(3)_turmas_com_melhoria.py
+++ b/pages/(3)_turmas_com_melhoria.py
@@ -20,7 +20,6 @@ query = '''WITH alunos_totais AS (
     SELECT 
         c.id AS turma_id,
         c.name AS nome_turma,
-        t.created_at AS data_cadastro_professor,
         t.id AS professor_id,  -- Incluir o ID do professor
         COUNT(DISTINCT s.id) AS total_alunos
     FROM 
@@ -38,8 +37,8 @@ alunos_melhoria AS (
         c.id AS turma_id,
         c.year AS ano_turma,
         c.cod_inep AS cod_inep_turma,
-        t.created_at AS data_cadastro_professor,
         t.id AS professor_id,  
+        das.created_at AS data_sondagem, 
         MIN(dh.ordering) AS min_ordering,
         MAX(dh.ordering) AS max_ordering
     FROM 
@@ -61,15 +60,15 @@ alunos_com_melhoria AS (
         turma_id,
         ano_turma,
         cod_inep_turma,
-        data_cadastro_professor,
         professor_id,
+        data_sondagem, 
         COUNT(aluno_id) AS alunos_com_melhoria
     FROM 
         alunos_melhoria
     WHERE 
         min_ordering < max_ordering  -- Filtra alunos que melhoraram de nível
     GROUP BY 
-        turma_id, professor_id
+        turma_id, professor_id, data_sondagem
 )
 SELECT 
     t.turma_id as id_turma,
@@ -79,11 +78,11 @@ SELECT
     sc.name AS nome_escola,
     sc.municipio AS cidade_escola,
     sc.uf AS estado_escola,
-    t.data_cadastro_professor as data_cadastro_professor,
     t.professor_id as id_professor,  
     t.total_alunos,
     COALESCE(m.alunos_com_melhoria, 0) AS alunos_com_melhoria,
-    ROUND((COALESCE(m.alunos_com_melhoria, 0) / t.total_alunos) * 100, 2) AS porcentagem_melhoria
+    ROUND((COALESCE(m.alunos_com_melhoria, 0) / t.total_alunos) * 100, 2) AS porcentagem_melhoria,
+    m.data_sondagem AS data_sondagem
 FROM 
     alunos_totais t
 LEFT JOIN 


### PR DESCRIPTION
Adicionando campo data da sondagem na tela de "Alunos com melhoria".

Havia sido inserido antes o campo de data de cadastro do professor, na verdade seria a data da sondagem.