### PR TITLE
feat: add-campo-mes-sondagem

### DIFF
--- a/pages/(3)_turmas_com_melhoria.py
+++ b/pages/(3)_turmas_com_melhoria.py
@@ -38,7 +38,7 @@ alunos_melhoria AS (
         c.year AS ano_turma,
         c.cod_inep AS cod_inep_turma,
         t.id AS professor_id,  
-        da.month as mes_sondagem,
+        CAST(da.month as UNSIGNED) AS mes_sondagem,
         MIN(dh.ordering) AS min_ordering,
         MAX(dh.ordering) AS max_ordering
     FROM 


### PR DESCRIPTION
- Adicionando campo mes na tala de turmas com melhoria e convertendo para int
O campo estava como string na origem do banco, trazendo como inteiro. 

O que aconteceu?

Após inserir como string no filtro quando digitado apenas número 2, está retornando os meses 2 e 12.