### PR TITLE
fit: correcao-tela-hipoteses

### DIFF
--- a/pages/(4)_hipóteses.py
+++ b/pages/(4)_hipóteses.py
@@ -124,7 +124,8 @@ SELECT
     rh.mes_de_aplicacao,
     rh.created_at AS data_criacao_sondagem,
     rh.updated_at AS data_atualizacao_sondagem,
-    rh.num_sondagem
+    rh.num_sondagem,
+    rh.cod_inep
 FROM 
     alunos_detalhes ad
 LEFT JOIN 


### PR DESCRIPTION
- A tela de hipoteses está dando um erro de código possivelmente por não existir o campo cod_inep na consulta final